### PR TITLE
fix(core): depth when including main.inc.php

### DIFF
--- a/htdocs/timesheet/core/lib/includeMain.lib.php
+++ b/htdocs/timesheet/core/lib/includeMain.lib.php
@@ -26,18 +26,14 @@ $currentTimesheetPath = dirname(__FILE__);
 if (! $res && file_exists($currentTimesheetPath."/dev.inc.php")) {
     include $currentTimesheetPath.'/dev.inc.php';
 }
-//if (! $res && ! empty($_SERVER["CONTEXT_DOCUMENT_ROOT"])) $res = @include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php";
-if (! $res && file_exists($currentTimesheetPath."/../../../main.inc.php")) {
-    $res = @include $currentTimesheetPath.'/../../../main.inc.php';// in HTdocs
-    //$_SERVER["CONTEXT_DOCUMENT_ROOT"] = realpath($currentTimesheetPath."/../../../");
-}
-if (! $res && file_exists($currentTimesheetPath."/../../../../main.inc.php")) {
-    $res = @include $currentTimesheetPath.'/../../../../main.inc.php';//in custom
-    //$_SERVER["CONTEXT_DOCUMENT_ROOT"] = realpath($currentTimesheetPath."/../../../../");
-}
-if (! $res && file_exists($currentTimesheetPath."/../../../../../main.inc.php")) {
-    $res = @include $currentTimesheetPath.'/../../../../../main.inc.php';//in custom
-    //$_SERVER["CONTEXT_DOCUMENT_ROOT"] = realpath($currentTimesheetPath."/../../");
+$maxDepth = 6;
+for ($i = 3; $i <= $maxDepth && !$res; $i++) {
+    $dirPath = $currentTimesheetPath . str_repeat("/..", $i) . "/";
+    $filePath = $dirPath . "main.inc.php";
+    if (! $res && file_exists($filePath)) {
+        $res = @include $filePath;
+        //$_SERVER["CONTEXT_DOCUMENT_ROOT"] = realpath($dirPath);
+    }
 }
 if (! $res) die("Include of main fails") ;
 


### PR DESCRIPTION
as I included the timesheet module by cloning the repo in the custom folder and just did a symlink from dolibarr_project_timesheet/htdocs/timesheet to timesheet, including main.inc.php with multiple /.. was not working anymore.

best option would have been to use the DOL_DOCUMENT_ROOT but the constant is not included at this time of execution.

I know the option I suggest is clearly not the perfect one because if the folder is not in custom, it will not work.
I´m totally open if you have another solution and I will understand if this PR is rejected.

also the improvement of the code (deduplication of code) can be kept with just a maxDepth of 5 (for same behaviour as today)

Tested with dolibarr 18.0.2 and branch dolibarr-18 of the module