### PR TITLE
Feature/support task billable

### DIFF
--- a/htdocs/timesheet/TimesheetProjectInvoice.php
+++ b/htdocs/timesheet/TimesheetProjectInvoice.php
@@ -73,6 +73,7 @@ if (empty($dateStart) || empty($dateEnd) ||$dateStart == $dateEnd) {
  $langs->load("main");
 $langs->load("projects");
 $langs->load('timesheet@timesheet');
+$DOL_VERSION_SUP_21 = version_compare($DOL_VERSION, '21', '>=')
 //steps
     switch($step) {
         case 2:
@@ -85,11 +86,18 @@ $langs->load('timesheet@timesheet');
             }
             $sql .= ' From '.MAIN_DB_PREFIX.'element_time as tt';
             $sql .= ' JOIN '.MAIN_DB_PREFIX.'projet_task as t ON tt.fk_element = t.rowid';
-            if ($invoicabletaskOnly == 1)$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'projet_task_extrafields as tske ON tske.fk_object = t.rowid ';
+            if ($invoicabletaskOnly == 1 && !$DOL_VERSION_SUP_21)$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'projet_task_extrafields as tske ON tske.fk_object = t.rowid ';
             $sql .= " WHERE tt.elementtype = 'task' and t.fk_projet=".$projectId;
             $sql .= " AND DATE(tt.element_datehour) BETWEEN '".$db->idate($dateStart);
                 $sql .= "' AND '".$db->idate($dateEnd)."'";
-             if ($invoicabletaskOnly == 1)$sql .= ' AND tske.invoiceable = \'1\'';
+             if ($invoicabletaskOnly == 1){
+                if ($DOL_VERSION_SUP_21){
+                    $sql .= ' AND t.billable = \'1\''
+                }
+                else {
+                    $sql .= ' AND tske.invoiceable = \'1\'';
+                }
+             }
             if ($ts2Invoice!='all') {
                 /*$sql .= ' AND tt.rowid IN(SELECT GROUP_CONCAT(fk_project_s SEPARATOR ", ")';
                 $sql .= ' FROM '.MAIN_DB_PREFIX.'project_task_time_approval';

--- a/htdocs/timesheet/TimesheetProjectInvoice.php
+++ b/htdocs/timesheet/TimesheetProjectInvoice.php
@@ -73,7 +73,7 @@ if (empty($dateStart) || empty($dateEnd) ||$dateStart == $dateEnd) {
  $langs->load("main");
 $langs->load("projects");
 $langs->load('timesheet@timesheet');
-$DOL_VERSION_SUP_21 = version_compare($DOL_VERSION, '21', '>=')
+$DOL_VERSION_SUP_21 = version_compare(DOL_VERSION, '21', '>=');
 //steps
     switch($step) {
         case 2:
@@ -92,7 +92,7 @@ $DOL_VERSION_SUP_21 = version_compare($DOL_VERSION, '21', '>=')
                 $sql .= "' AND '".$db->idate($dateEnd)."'";
              if ($invoicabletaskOnly == 1){
                 if ($DOL_VERSION_SUP_21){
-                    $sql .= ' AND t.billable = \'1\''
+                    $sql .= ' AND t.billable = \'1\'';
                 }
                 else {
                     $sql .= ' AND tske.invoiceable = \'1\'';

--- a/htdocs/timesheet/class/TimesheetReport.class.php
+++ b/htdocs/timesheet/class/TimesheetReport.class.php
@@ -233,7 +233,7 @@ class TimesheetReport
         global $conf;
         $resArray = array();
         $first = true;
-        $INVOICABLE_SQL= version_compare($DOL_VERSION, 21, '>=') ?  't.billable':'tske.invoiceable' 
+        $INVOICABLE_SQL= version_compare(DOL_VERSION, 21, '>=') ? 't.billable' : 'tske.invoiceable';
         $sql = 'SELECT tsk.fk_projet as projectid, ptt.fk_user  as userid, tsk.rowid as taskid, ';
         $sql .= ' (ptt.invoice_id > 0 or ptt.invoice_line_id>0)  AS invoiced,';
         if ($forceGroup == 1){

--- a/htdocs/timesheet/class/TimesheetReport.class.php
+++ b/htdocs/timesheet/class/TimesheetReport.class.php
@@ -233,18 +233,18 @@ class TimesheetReport
         global $conf;
         $resArray = array();
         $first = true;
-
+        $INVOICABLE_SQL= version_compare($DOL_VERSION, 21, '>=') ?  't.billable':'tske.invoiceable' 
         $sql = 'SELECT tsk.fk_projet as projectid, ptt.fk_user  as userid, tsk.rowid as taskid, ';
         $sql .= ' (ptt.invoice_id > 0 or ptt.invoice_line_id>0)  AS invoiced,';
         if ($forceGroup == 1){
             if ($this->db->type!='pgsql') {
-                $sql .= " MAX(ptt.rowid) as id, GROUP_CONCAT(ptt.note SEPARATOR '. ') as note, MAX(tske.invoiceable) as invoicable, ";
+                $sql .= " MAX(ptt.rowid) as id, GROUP_CONCAT(ptt.note SEPARATOR '. ') as note, MAX($INVOICABLE_SQL) as invoicable, ";
             } else {
-                $sql .= " MAX(ptt.rowid) as id, STRING_AGG(ptt.note, '. ') as note, MAX(tske.invoiceable) as invoicable, ";
+                $sql .= " MAX(ptt.rowid) as id, STRING_AGG(ptt.note, '. ') as note, MAX($INVOICABLE_SQL) as invoicable, ";
             }
             $sql .= ' DATE(ptt.element_datehour) AS element_date, SUM(ptt.element_duration) as duration ';
         }else{
-            $sql .= " ptt.rowid as id, ptt.note  as note, tske.invoiceable as invoicable, ";
+            $sql .= " ptt.rowid as id, ptt.note  as note, $INVOICABLE_SQL as invoicable, ";
             $sql .= ' DATE(ptt.element_datehour) AS element_date, ptt.element_duration as duration ';
         } 
         $sql .= ' FROM '.MAIN_DB_PREFIX.'element_time as ptt ';

--- a/htdocs/timesheet/core/modules/modtimesheet.class.php
+++ b/htdocs/timesheet/core/modules/modtimesheet.class.php
@@ -565,7 +565,7 @@ class modTimesheet extends DolibarrModules
             // allow ext id of 32 char
            // $extrafields->addExtraField('external_id', "ExternalId", 'varchar', 100, 32, 'user', 1, 0, '', '', 1, '$user->rights->timesheet->AttendanceAdmin', 3, 'specify the id of the external system', '', 0, 'timesheet@ptimesheet', '$conf->global->ATTENDANCE_EXT_SYSTEM');
             // add the "invoicable" bool to the task
-            $extrafields->addExtraField('invoiceable', "Invoiceable", 'boolean', 1, '', 'projet_task', 0, 0, '', '', 1, 1, 1, 0, '', 0, 'timesheet@timesheet', '$conf->timesheet->enabled');
+            if version_compare($DOL_VERSION, 21, '>=') $extrafields->addExtraField('invoiceable', "Invoiceable", 'boolean', 1, '', 'projet_task', 0, 0, '', '', 1, 1, 1, 0, '', 0, 'timesheet@timesheet', '$conf->timesheet->enabled');
             return $this->_init($sql, $options);
         }
         /**


### PR DESCRIPTION
Added migration (and disablement) of invoiceable project task extrafield to billable project task attribute when Module is activated. User should be encouraged to re-init the module after upgrading to Dolibarr 21.

Migration apply only to version >= 21.

Also corrected typos in DOL_VERSION constant name.