### PR TITLE
Fix for recent versions.

### DIFF
--- a/htdocs/timesheet/TimesheetProjectInvoice.php
+++ b/htdocs/timesheet/TimesheetProjectInvoice.php
@@ -70,7 +70,7 @@ if (empty($dateStart) || empty($dateEnd) ||$dateStart == $dateEnd) {
     $dateStart = strtotime("first day of previous month", time());
     $dateEnd = strtotime("last day of previous month", time());
 }
- $langs->load("main");
+$langs->load("main");
 $langs->load("projects");
 $langs->load('timesheet@timesheet');
 //steps
@@ -81,7 +81,7 @@ $langs->load('timesheet@timesheet');
             if ($db->type!='pgsql') {
                 $sql .= " GROUP_CONCAT(tt.rowid  SEPARATOR ', ') as task_time_list";
             } else{
-                $sql .= " STRING_AGG(to_char(tt.rowid, '9999999999999999'), ', ') as task_time_list";
+                $sql .= " STRING_AGG(tt.rowid::TEXT, ', ') as task_time_list";
             }
             $sql .= ' From '.MAIN_DB_PREFIX.'element_time as tt';
             $sql .= ' JOIN '.MAIN_DB_PREFIX.'projet_task as t ON tt.fk_element = t.rowid';


### PR DESCRIPTION
I was getting following errors while trying to "invoice time spent":

2026-01-06 16:38:46 DEBUG   192.168.1.37      67177     67 sql=SELECT
fk_element, SUM(tt.element_duration) as duration,
STRING_AGG(to_char(tt.rowid::TEXT, '9999999999999999'::TEXT), ',
 ') as task_time_list From llx_element_time as tt JOIN llx_projet_task
as t ON tt.fk_element = t.rowid WHERE tt.elementtype = 'task' and
t.fk_projet=111 AND DATE(tt.element_datehour) BET
WEEN '2025-12-01 00:00:00' AND '2025-12-31 00:00:00' GROUP BY fk_element
2026-01-06 16:38:46 ERR     192.168.1.37      67177     67
DoliDBPgsql::query SQL Error message: ERROR:  42883: function
to_char(text, text) does not exist
LINE 1: ...SUM(tt.element_duration) as duration,
STRING_AGG(to_char(tt...
                                                             ^
HINT:  No function matches the given name and argument types. You might
need to add explicit type casts.